### PR TITLE
Switch to Kotlin embeddable compiler v1.3.0

### DIFF
--- a/ast-psi/src/main/kotlin/kastree/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/kastree/ast/psi/Converter.kt
@@ -1,12 +1,12 @@
 package kastree.ast.psi
 
-import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
 import kastree.ast.ExtrasMap
 import kastree.ast.Node
 import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*

--- a/ast-psi/src/main/kotlin/kastree/ast/psi/Parser.kt
+++ b/ast-psi/src/main/kotlin/kastree/ast/psi/Parser.kt
@@ -1,11 +1,11 @@
 package kastree.ast.psi
 
-import com.intellij.openapi.util.Disposer
-import com.intellij.psi.PsiErrorElement
-import com.intellij.psi.PsiManager
-import com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile

--- a/ast-psi/src/test/kotlin/kastree/ast/psi/CorpusTest.kt
+++ b/ast-psi/src/test/kotlin/kastree/ast/psi/CorpusTest.kt
@@ -1,9 +1,9 @@
 package kastree.ast.psi
 
-import com.intellij.openapi.util.text.StringUtilRt
-import com.intellij.psi.PsiElement
 import kastree.ast.Node
 import kastree.ast.Writer
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.junit.Assume
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.3.0'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ project(':ast-psi') {
     dependencies {
         compile project(':ast:ast-jvm')
         compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-        compile "org.jetbrains.kotlin:kotlin-compiler:$kotlin_version"
+        compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
         testCompile 'junit:junit:4.12'
         testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
         testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"


### PR DESCRIPTION
Resolves #4.

Updates all Kotlin dependencies to v1.3.0 (stable release) and switches out the `kotlin-compiler` dependency for `kotlin-compiler-embeddable`.

All unit tests continue to pass (or skip) as before, and using my fork as an [included build](https://docs.gradle.org/current/userguide/composite_builds.html) I verify that I can use this library alongside other libraries like kotlintest.