### PR TITLE
Fix CallConstructor rendering

### DIFF
--- a/ast/ast-common/src/main/kotlin/kastree/ast/Writer.kt
+++ b/ast/ast-common/src/main/kotlin/kastree/ast/Writer.kt
@@ -93,7 +93,6 @@ open class Writer(
                 }
                 is Node.Decl.Structured.Parent.CallConstructor -> {
                     children(type)
-                    bracketedChildren(typeArgs)
                     parenChildren(args)
                 }
                 is Node.Decl.Structured.Parent.Type -> {


### PR DESCRIPTION
Parser input:
```kotlin
private object SubnetSorter : DefaultSorter<Subnet>()
```
Writer output:
```kotlin
private object SubnetSorter : DefaultSorter<Subnet><Subnet>()
```
Expected output:
```kotlin
private object SubnetSorter : DefaultSorter<Subnet>()
```
Solution:`typeArgs` are present both in `CallConstructor.type` and in `CallConstructor` structures. We don't need to call `bracketedChildren` twice