### PR TITLE
Fix character escaping

### DIFF
--- a/ast/ast-common/src/main/kotlin/kastree/ast/Writer.kt
+++ b/ast/ast-common/src/main/kotlin/kastree/ast/Writer.kt
@@ -292,7 +292,13 @@ open class Writer(
                 is Node.Expr.StringTmpl.Elem.UnicodeEsc ->
                     append("\\u").append(digits)
                 is Node.Expr.StringTmpl.Elem.RegularEsc ->
-                    append('\\').append(char)
+                    append('\\').append(when (char) {
+                        '\b' -> 'b'
+                        '\n' -> 'n'
+                        '\t' -> 't'
+                        '\r' -> 'r'
+                        else -> char
+                    })
                 is Node.Expr.StringTmpl.Elem.LongTmpl ->
                     append("\${").also { children(expr) }.append('}')
                 is Node.Expr.Const ->


### PR DESCRIPTION
Parser input:
```kotlin
val x = "input\b\n\t\r\'\"\\\$"
```
Writer output:
```kotlin
val x = "input\\

\	\
\'\"\\\$"
```
Expected output:
```kotlin
val x = "input\b\n\t\r\'\"\\\$"
```