### PR TITLE
Fix missing modifiers in KtTypeProjection

### DIFF
--- a/ast-psi/src/main/kotlin/kastree/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/kastree/ast/psi/Converter.kt
@@ -553,7 +553,13 @@ open class Converter {
         block = convertBlock(v.catchBody as? KtBlockExpression ?: error("No catch block for $v"))
     ).map(v)
 
-    open fun convertType(v: KtTypeProjection) = v.typeReference?.let { convertType(it) }
+    open fun convertType(v: KtTypeProjection) =
+        v.typeReference?.let { convertType(it, v.modifierList) }
+
+    open fun convertType(v: KtTypeReference, modifierList: KtModifierList?): Node.Type = Node.Type(
+        mods = convertModifiers(modifierList),
+        ref = convertTypeRef(v)
+    ).map(v)
 
     open fun convertType(v: KtTypeReference): Node.Type = Node.Type(
         // Paren modifiers are inside the ref...


### PR DESCRIPTION
Parser input:
```kotlin
fun delete(p: Array<out String>?) {}
```
Writer output:
```kotlin
fun delete(p: Array<String>?) {}
```
Expected output:
```kotlin
fun delete(p: Array<out String>?) {}
```

## Details
The problem is that we lose some information about ast during conversion. It turned out that convertType method was not using `KtTypeProjection` `modifierList`. This patch fixed the particular problem, but I'm not sure if there are no more missing modifiers related bugs