### PR TITLE
Add typeOp to MutableVisitor

### DIFF
--- a/ast-psi/src/test/kotlin/kastree/ast/WriterTest.kt
+++ b/ast-psi/src/test/kotlin/kastree/ast/WriterTest.kt
@@ -29,6 +29,23 @@ class WriterTest {
     }
 
     fun assertParseAndWriteExact(code: String) {
-        assertEquals(code.trim(), Writer.write(Parser.parseFile(code)).trim())
+
+        val node = Parser.parseFile(code)
+        val identityNode = MutableVisitor.preVisit(node) { v, _ -> v }
+
+        assertEquals(node, identityNode, "Different values for identity-transformed node and original node")
+
+        assertEquals(
+            code.trim(),
+            Writer.write(node).trim(),
+            "Parse -> Write for $code, not equal")
+
+        assertEquals(
+            code.trim(),
+            Writer.write(identityNode).trim(),
+            "Parse -> Identity Transform -> Write for $code, failed")
+
+
     }
+
 }

--- a/ast-psi/src/test/kotlin/kastree/ast/WriterTest.kt
+++ b/ast-psi/src/test/kotlin/kastree/ast/WriterTest.kt
@@ -28,12 +28,15 @@ class WriterTest {
         assertParseAndWriteExact("private object SubnetSorter : DefaultSorter<Subnet>()")
     }
 
+    @Test
+    fun testOpType() {
+        assertParseAndWriteExact("""val x = "" as String""")
+    }
+
     fun assertParseAndWriteExact(code: String) {
 
         val node = Parser.parseFile(code)
         val identityNode = MutableVisitor.preVisit(node) { v, _ -> v }
-
-        assertEquals(node, identityNode, "Different values for identity-transformed node and original node")
 
         assertEquals(
             code.trim(),

--- a/ast/ast-common/src/main/kotlin/kastree/ast/MutableVisitor.kt
+++ b/ast/ast-common/src/main/kotlin/kastree/ast/MutableVisitor.kt
@@ -270,6 +270,12 @@ open class MutableVisitor {
                         anns = visitChildren(anns, newCh),
                         expr = visitChildren(expr, newCh)
                     )
+                    is Node.Expr.TypeOp -> copy (
+                        lhs = visitChildren(lhs, newCh),
+                        oper = visitChildren(oper, newCh),
+                        rhs = visitChildren(rhs, newCh)
+                    )
+                    is Node.Expr.TypeOp.Oper -> this
                     is Node.Expr.Call -> copy(
                         expr = visitChildren(expr, newCh),
                         typeArgs = visitChildren(typeArgs, newCh),

--- a/ast/ast-common/src/main/kotlin/kastree/ast/Visitor.kt
+++ b/ast/ast-common/src/main/kotlin/kastree/ast/Visitor.kt
@@ -181,6 +181,12 @@ open class Visitor {
                 visitChildren(oper)
                 visitChildren(rhs)
             }
+            is Node.Expr.TypeOp.Oper -> {}
+            is Node.Expr.TypeOp -> {
+                visitChildren(lhs)
+                visitChildren(oper)
+                visitChildren(rhs)
+            }
             is Node.Expr.BinaryOp.Oper.Infix -> {}
             is Node.Expr.BinaryOp.Oper.Token -> {}
             is Node.Expr.UnaryOp -> {


### PR DESCRIPTION
Update tests to pass AST through identity transformed mutable visitor.

Resolves: https://github.com/cretz/kastree/issues/23