### PR TITLE
Bump to kotlin 1.3.41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Bumps the Kotlin version to 1.3.41 as I had problems using the kastree library in projects that are built against latest Kotlin.